### PR TITLE
Adapted mvc-react-portlet to Liferay 7.3.1 ga2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 build/
 node_modules/
 target/
+.idea/
 .DS_Store

--- a/.npmbundlerrc
+++ b/.npmbundlerrc
@@ -2,8 +2,8 @@
 	"config": {
 		"imports": {
 			"frontend-js-react-web": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
+				"react": ">=16.12.0",
+				"react-dom": ">=16.12.0"
 			}
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MVC React Portlet
 
-A sample Liferay portlet built to highlight best practices.
+A sample Liferay portlet built to highlight best practices, built and tested for Liferay CE 7.3.1 GA2.
 
 This is a discussion that is in progress and has yet to be solidified.
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,6 @@ dependencies {
 	compileOnly group: "jstl", name: "jstl", version: "1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 
-	compileOnly group: "com.liferay", name: "org.apache.felix.gogo.runtime", version: "1.1.0.LIFERAY-PATCHED-2"
-	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
-
 	compileOnly group: "com.liferay", name: "com.liferay.frontend.taglib", version: "5.1.1"
 	compileOnly group: "com.liferay", name: "com.liferay.frontend.taglib.clay", version: "3.3.1"
 	compileOnly group: "com.liferay", name: "com.liferay.frontend.taglib.react", version: "4.0.3"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "4.5.3"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "4.5.36"
 	}
 
 	repositories {
@@ -13,8 +13,8 @@ buildscript {
 apply plugin: "com.liferay.plugin"
 
 dependencies {
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "4.4.0"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "4.0.8"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "5.4.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "5.0.3"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "jstl", name: "jstl", version: "1.2"
@@ -23,9 +23,9 @@ dependencies {
 	compileOnly group: "com.liferay", name: "org.apache.felix.gogo.runtime", version: "1.1.0.LIFERAY-PATCHED-2"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 
-	compileOnly group: "com.liferay", name: "com.liferay.frontend.taglib", version: "4.0.32"
-	compileOnly group: "com.liferay", name: "com.liferay.frontend.taglib.clay", version: "2.2.19"
-	compileOnly group: "com.liferay", name: "com.liferay.frontend.taglib.react", version: "1.0.2"
+	compileOnly group: "com.liferay", name: "com.liferay.frontend.taglib", version: "5.1.1"
+	compileOnly group: "com.liferay", name: "com.liferay.frontend.taglib.clay", version: "3.3.1"
+	compileOnly group: "com.liferay", name: "com.liferay.frontend.taglib.react", version: "4.0.3"
 }
 
 repositories {

--- a/gradlew
+++ b/gradlew
@@ -1,5 +1,21 @@
 #!/usr/bin/env sh
 
+#
+# Copyright 2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ##############################################################################
 ##
 ##  Gradle start up script for UN*X
@@ -28,7 +44,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
@@ -109,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,3 +1,19 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
 @if "%DEBUG%" == "" @echo off
 @rem ##########################################################################
 @rem
@@ -14,7 +30,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"@clayui/drop-down": "^3.2.0",
 		"@clayui/form": "^3.4.0",
 		"@clayui/tabs": "^3.0.6",
-		"react": "^16.9.0"
+		"react": "16.12.0"
 	},
 	"description": "",
 	"main": "js/Index.es.js",
@@ -21,7 +21,7 @@
 		"@babel/core": "^7.7.5",
 		"@babel/preset-env": "^7.7.6",
 		"@babel/preset-react": "^7.7.4",
-		"liferay-npm-bundler": "^2.16.1",
-		"liferay-npm-build-support": "^2.16.1"
+		"liferay-npm-bundler": "^2.17.1",
+		"liferay-npm-build-support": "^2.17.1"
 	}
 }


### PR DESCRIPTION
Changes summary:
- Merged OSGi module versions and gradle support files with Portlet MVC plugin created with `blade` for 7.3
- Updated versions of `react`, `liferay-npm-bundler` and `liferay-npm-build-support` to the ones generated by `yo liferay-js` for 7.3